### PR TITLE
ci: make ccache aware of matrix builds

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -29,7 +29,7 @@ build:
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 
     ci:
-      - export CCACHE_DIR=${SHIPPABLE_BUILD_DIR}/ccache/.ccache
+      - export CCACHE_DIR=${SHIPPABLE_BUILD_DIR}/ccache/${MATRIX_BUILD}/.ccache
       - >
         if [ "$IS_PULL_REQUEST" = "true" ]; then
           git rebase origin/${PULL_REQUEST_BASE_BRANCH};


### PR DESCRIPTION
Our matrix distribution is not random and in most cases we build the
same architectures and tests on the same matrix build, over and over
again, so that ccache becomes useless when pulled from matrix build X to
matrix build Y.

This will create a ccache file per matrix file to increase performance.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>