### PR TITLE
docker: use new docker

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -24,7 +24,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.4-rc2
+        image_tag: v0.4-rc5
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
Use docker image 0.4-rc5 with new ccache

Signed-off-by: Anas Nashif <anas.nashif@intel.com>