### PR TITLE
github: fix doc-build

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -16,11 +16,7 @@ jobs:
         sudo apt-get install -y ninja-build doxygen
     - name: build-requirements.txt
       run: |
-         curl -o requirements.txt -L https://raw.githubusercontent.com/zephyrproject-rtos/ci-tools/master/requirements.txt
-         echo cmake >> requirements.txt
-         echo setuptools >> requirements.txt
-         cat scripts/requirements.txt requirements.txt | sort -u > requirements.txt
-         cat requirements.txt
+         cp scripts/requirements.txt requirements.txt
     - name: cache-pip
       uses: actions/cache@v1
       with:
@@ -30,6 +26,7 @@ jobs:
           ${{ runner.os }}-pip-          
     - name: install-pip
       run: |
+        pip3 install setuptools
         pip3 install -r requirements.txt
     - name: cache-zephyr-modules
       uses: actions/cache@v1


### PR DESCRIPTION
the python pip setup needed tweaking.  For now don't grab the python
requirements from ci-tools, and skip trying to merge it with zephyr repo
requirements.txt.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>