### PR TITLE
test1

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -61,6 +61,9 @@ jobs:
           west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'
 
+          sudo apt-get update
+          sudo apt-get install curl
+
       - name: Check Environment
         run: |
           cmake --version

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -61,8 +61,8 @@ jobs:
           west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'
 
-          sudo apt-get update
-          sudo apt-get install curl
+          sudo apt-get -y update
+          sudo apt-get -y install curl
 
       - name: Check Environment
         run: |
@@ -80,7 +80,6 @@ jobs:
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
           cmake -Bbuild -Ssamples/synchronization -DBOARD=native_posix -GNinja
-          cd build
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/
       - name: Run sonar-scanner
         env:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -89,6 +89,7 @@ jobs:
         run: |
           export SONAR_TOKEN=${{ secrets.SONAR_TOKEN }}
           sonar-scanner \
+          -X \
           -Dsonar.organization=zephyrproject-rtos \
           -Dsonar.projectKey=zephyrproject-rtos_zephyr-testing \
           -Dsonar.sources=. \

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -76,7 +76,7 @@ jobs:
         uses: SonarSource/sonarcloud-github-c-cpp@v1
       - name: Run build-wrapper
         run: |
-          cmake -Bbuild -Ssamples/synchronization-DBOARD=native_posix -GNinja
+          cmake -Bbuild -Ssamples/synchronization -DBOARD=native_posix -GNinja
           cd build
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/
       - name: Run sonar-scanner

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -76,6 +76,9 @@ jobs:
         uses: SonarSource/sonarcloud-github-c-cpp@v1
       - name: Run build-wrapper
         run: |
+          ls -la /opt/
+          export ZEPHYR_BASE=${PWD}
+          export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
           cmake -Bbuild -Ssamples/synchronization -DBOARD=native_posix -GNinja
           cd build
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -15,7 +15,7 @@ jobs:
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject
     env:
-      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
+      BUILD_WRAPPER_OUT_DIR: bw_output # Directory where build-wrapper output will be placed
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.2
       TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 '
@@ -87,6 +87,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
+          export SONAR_TOKEN=${{ secrets.SONAR_TOKEN }}
           sonar-scanner \
           -Dsonar.organization=zephyrproject-rtos \
           -Dsonar.projectKey=zephyrproject-rtos_zephyr-testing \

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -16,6 +16,7 @@ jobs:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.2
       TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 '
       DAILY_OPTIONS: ' -M --build-only --all --show-footprint'
@@ -86,4 +87,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner \
+          -Dsonar.organization=zephyrproject-rtos \
+          -Dsonar.projectKey=zephyrproject-rtos_zephyr-testing \
+          -Dsonar.sources=. \
+          -Dsonar.host.url=https://sonarcloud.io \
+          --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+
+
 .. raw:: html
 
    <a href="https://www.zephyrproject.org">


### PR DESCRIPTION
- arch/arm/core: fixup typo
- net: icmpv6: fix if need calc tx checksum
- drivers: wifi: eswifi: Offload sockets regression
- driver: gpio: rt1718s: Add RT1718S GPIO driver
- drivers: flash: sam0: Resolve write issues in the first row
- lorawan: enforce larger system work queue stack size via Kconfig
- driver: gpio: npcx: correct the usage of npcx voltage flags
- tests: drivers: clock_control: stm32: fix H7 zassert output
- drivers: eth_e1000: Remove zero hadrcoded TDBAH, RDBAH
- drivers: eth_e1000: Allow several instances
- samples: net: Add qemu_x86_64 to platform_allow
- samples: Bluetooth: Increase subgroup count for broadcast audio sink
- intel_adsp: strip rimage main.mod when CONFIG_BUILD_OUTPUT_STRIPPED
- soc: stm32u5: Replace IMGTOOL_ARGS with ROM_START_OFFSET
- Bluetooth: Add legacy warning to `Kconfig.template.log_config_bt`
- drivers: sdhc: have sdhc-spi-slot declare an sd bus
- scripts: compliance: Remove unneeded workaround
- scripts: compliance: Remove old TODO
- scripts: compliance: Consolidate 'git diff' calls in get_files()
- scripts: compliance: Make line optional in fmtd_failure()
- scripts: compliance: Clean up ZEPHYR_BASE usage
- scripts: compliance: Resolve ZEPHYR_BASE in _main()
- scripts: compliance: Move Kconfig-related items to the class
- Bluetooth: Audio: Rename vcs.h to vcp.h as well as the Kconfig file
- Bluetooth: Audio: Rename VCS to VCP
- Bluetooth: Audio: Remove the bt_vcp_aics API
- Bluetooth: Audio: Remove the bt_vcp_vocs API
- Bluetooth: Audio: Add separate API for VCP vol controller
- Bluetooth: Audio: Specify bt_vcp_vol_rend API
- Bluetooth: Audio: Split vol_ctlr and vol_rend callback structure
- Bluetooth: Audio: Remove bt_vcp from vol rend API
- Bluetooth: Audio: Vol rend use `bt_vcp_vol_rend` instead of `bt_vcp`
- Bluetooth: Audio: Use `bt_vcp_vol_ctlr` instead of `bt_vcp`
- ARC: boards: nsim_hs: add missing MPU enabling
- drivers: dai: intel: dmic: fix periodic start
- ARC: ARCv2: GCC: restore default TLS behavior for all SDKs
- ARC: TLS: cleanup tls register setup
- ARC: make ARC_MP_PRIMARY_CPU_ID definition public
- ARC: control shared (common) interrupts via IDU
- boards: olimex_lora_stm32wl_devkit: enable MPU and HW stack protection
- include: Add i2c helper methods for async implementation
- twister: fix simulation conditional
- unittest: add support for coverage
- dts: add clkctl definition
- intel_common: clean up & rename cavs_* to adsp_*
- tests: adsp_clock: update tests
- include: sys: crc: add crc_by_type inline dispatch function
- lib: os: add CRC shell command for integrity verification
- ARC: arcmwdt: fix & rework inclusion of C/C++ headers
- ARC: MWDT: bump toolchain version
- ARC: MWDT add TLS support
- ARC: cleanup & modify _st32_huge_offset as it becomes widely used
- tests: drivers: nrf_lf_clock_control: Fix test initialization
- tests: drivers: nrf_lf_clock_control: Polish status messages a bit
- soc: riscv: andes_v5: Fix system initialization for L2C
- boards: esp32: enable BOOT button
- Bluetooth: Audio: Fix broadcast assistant recv state pointer value
- drivers: flash: Do not unlock CR at the end of initialization
- kernel: sched: fix ticks logging
- dts: arm: st: add STM32F302xC device tree
- drivers: flash: stm32 ospi flash driver for stm32l4plus mcus
- dts: arm: stm32l4plus serie has octospi peripheral instead of quadspi
- boards: arm: stm32l4s5 disco kit with octospi on board
- samples: drivers: jesd216 jedec ID and SFDP from octo-flash
- samples: tfm_integration: psa_firmware: Improve logging handling
- logging: Enable LOG_PRINTK if PRINTK is enabled
- doc: logging: Add section about LOG_PRINTK option
- logging: Increase dummy shell buffer size to 400 bytes for LOG_PRINTK
- tests: logging: log_core_additional: Align test to LOG_PRINTK changes
- tests: logging: log_syst: Align to LOG_PRINTK as default
- tests: logging: log_switch_format: Align to LOG_PRINTK as default
- tests: net: shell: Align to LOG_PRINTK as default
- tests: openthread: Align to LOG_PRINTK as default
- tests: logging: log_links: Align to LOG_PRINTK as default
- tests: logging: log_link_order: Align to LOG_PRINTK as default
- drivers: regulator: pca9420: improve instantiation code
- drivers: regulator: pca9420: rename some internal structs/funcs
- drivers: regulator: pca9420: fix voltage|current_range types
- drivers: regulator: pca9420: sort includes
- dts: bindings: regulator: regulator-name is common
- dts: bindings: regulator: import Linux properties
- drivers: regulator: pca9420: use standard regulator-min|max-microvolt
- dts: bindings: regulator: nxp,pca9420 use standard mode properties
- drivers: regulator: pca9420: do not use DT_PROP_OR for booleans
- drivers: regulator: pca9420: fixed child instantiation
- drivers: regulator: pca9420: remove unused registers
- drivers: regulator: pca9420: remove unused modesel offset
- drivers: regulator: pca9420: do not expose registers in DT
- dts: bindings: regulator: nxp,pca9420: add maximum current
- drivers: regulator: pca9420: refactor voltage range handling
- drivers: regulator: pca9420: fix VIN current limit setting
- drivers: regulator: pca9420: store common config in parent device
- dt-bindings: regulator: pca9420: reorganize headers/macros
- dts: bindings: clock: fix stm32h7 div-m description
- drivers: clock_control: stm32h7: add PLL2 support
- include: dt-bindings: clock: stm32h7 add PLL2 defines
- dts: arm: stm32: add PLL2 to stm32h7
- tests: drivers: clock_control: stm32: test H7 PLL2_P SPI1
- Bluetooth: Audio: Fix MCC disconnect issue
- dts: l5: stm32l5: Add rtc node
- drivers: counter: Enable support to stm32l5 mcu
- boards: stm32l562e_dk_ns: Enable rtc
- samples: drivers: counter: alarm: Add support to TFM
- tests/samples: use integration_plaforms in more tests/samples
- twister: get information about memory footprint from build.log
- drivers/mm: Only remap unused RAM on Kconfig on Intel ADSP MTL
- drivers: dai: add Intel HDA dai
- drivers: spi_context: fix some LOG_DBG warnings
- drivers: spi_mcux_lpspi: fix baudrate change when switching devices
- boards: stm32l496g_disco: Add USB support
- soc: lpcxpresso55S36 added PowerInit in clock_init.
- drivers: pinctrl: Microchip XEC PINCTRL add invert pin
- soc: nxp: s32ze: add option to select RTU index
- drivers: counter: support NXP S32 System Timer Module
- boards: arm: s32z270dc2_r52: enable System Timer
- samples: counter: support System Timer on s32z270dc2_r52
- tests: counter: support System Timer on s32z270dc2_r52
- Bluetooth: controller: set bit to indicate support for Request Peer SCA
- tests: bluetooth: host: Add UT for bt_keys_find_addr()
- Bluetooth: controller: adding missing NTF wait state to SCA procedure
- Bluetooth: controller: Add lock around LLCP data
- Bluetooth: Host: l2cap: disconnect when PDU > MPS
- Bluetooth: controller: fixup to peripheral CIS CREATE procedure
- Bluetooth: controller: fixup to peripheral CIS Create check instant
- driver: wifi: esp32: remove build warning
- driver: wifi: esp32: disable optimization by default
- linker: esp32: fix IRAM length for mcuboot
- scripts: west_commands: runners: remove deprecated options
- Logging: Add Kconfig template for log inheriting
- Bluetooth: Update Bluetooth legacy logging Kconfig
- Bluetooth: Remove conditionnal declaration of `bt_tbs_dbg_print_calls`
- drivers: regulator: fixed: simplify implementation
- drivers: regulator: drop async enable
- tests: drivers: regulator: fixed: fix broken test
- codeowners: add entry for regulators
- samples: external_lib: Add building on windows support
- tests: logging: log_immediate: Add LOG_PRINTK=n
- drivers: flash: stm32l5_u5: fix L5/U5 difference in FLASH_PAGE_NB
- drivers: flash: stm32l5_u5: refactor flash_stm32_page_layout() for clarity
- github: workflows: compliance: Ensure no merge commits
- checkpatch: Remove ext/ from excludes
- tests: kernel: do not set excluded  as integration platform
- dts: xtensa: intel: fix typo in domain name
- intel_adsp: ace: power header update
- power_domain: intel_adsp: code update
- ace: dts: dmic: add power domain
- drivers: dmic: enable runtime power mgmt in intel dmic
- drivers: dmic: add dependency for runtime pm
- bluetooth: host: smp: unauth bond overwrite on different identity
- samples: syslog_net: correctly late-initialize log backend
- samples: syslog_net: use utility function for backend init
- logging: allow disabling auto-start of UART backend
- MAINTAINERS: update collaborator list
- Bluetooth: controller: store STO value instead of pre-calculated reload
- Bluetooth: controller: fixing possible race re. termination vs. cis's
- Bluetooth: controller: Implementing CIS STO & establishment timeout
- twister: ignore unit tests/EFI images with --show-footprint
- twister: instance: fix layout
- tests: drivers: spi loopback on nucleo_l152 with DMA
- tests: drivers: spi_loopback on stm32f3_disco
- checkpatch: update --exclude docs
- Bluetooth: controller: Remove HCI_Read_Local_Supported_Codecs [v1]
- ITE drivers/pwm/it8xxx2: don't gate pwm clock when set cycle
- tests: Bluetooth: Remove setting a unused define
- Kconfig: net: Remove deprecated `NET_BUF_USER_DATA_LEN`
- net: Make user_data size in rx and tx buffers configurable
- west: runners: add file argument
- boards: qemu_x86: Do not build "raw" binary for qemu
- tests: entropy: api: Add nocache buffer option
- drivers: entropy: Fix MCUX CAAM Entropy
- boards: arduino_nano_33_ble: Support TRACE32 (GDB-Frontend)
- cache: Rework cache API
- tests: cache: Add cache test
- arm64: cache: Rework cache API
- arm: cache: Rework cache API
- arc: cache: Rework cache API
- cache: aspeed: Rework driver
- cache: Fix libraries and drivers
- manifest: libmetal: Use the new cache API
- manifest: openamp: Bump up openamp version
- posix: getopt: move declarations to unistd.h
- shell: devmem: add devmem dump subcommand
- Revert "shell: devmem: add devmem dump subcommand"
- Revert "posix: getopt: move declarations to unistd.h"
- Bluetooth: audio: shell: Fix VCP Volume Renderer build
- boards: arm: b_l4s5i_iot01a: fix OSPI flash size
- boards: arm: stm32h7b3i_dk: fix OSPI flash size
- ITE: soc: it81xx2: Add new variant of it81xx2cx related configuration
- include: adc: Add clarification about ADC buffer
- sys: linear_range: fix index calculation when spanning across groups
- drivers: led: Microchip XEC LED driver using BBLED controller
- dts: arm: mec1501: add bbled support for MEC1501
- samples: drivers: led: Add sample for Microchip XEC LED driver
- Bluetooth: Audio: Move some unicast shell commands to also support server
- Bluetooth: Audio: Remove `audio connect` command
- Bluetooth: Audio: add check for default_conn for `audio qos` shell command
- Bluetooth: Audio: Change shell print for default_stream == NULL checks
- dts: bindings: display: st7735r: add rgb-is-inverted option
- drivers: display: st7735r: Add rgb-is-inverted property
- Bluetooth: tester: Extract services from bttester
- dts: bindings: add fifo size properties to CDC ACM UART bindings
- include: usb_ch9: add macros to get endpoint attributes
- include: usb_cdc: add notification codes and UART state bitmap values
- drivers: usb: add new USB device controller API (UDC API)
- drivers: udc_nrf: implement method to distiguish hal and shim events
- drivers: udc_nrf: do not abuse HAL events for the driver's concerns.
- soc: expand ifdef by adding new Kconfig option UDC_KINETIS
- drivers: udc: add USBFSOTG UDC driver for Kinetis SoCs
- tests: drivers: add simple UDC driver test
- usb: add new experimental USB device stack
- doc: usb: add UDC driver API reference
- samples: usb: add shell sample for new USB support
- usb: device_next: add experimental CDC ACM implementation
- samples: cdc_acm: enable optional new USB device support
- samples: usb: console: enable optional new USB device support
- ci: twister: fixed path for tag based filtering
- MAINTAINERS.yml: Update x86 platform & arch maintainers
- usb-c: Generate USB-C connector VIF policies XML file
- kernel: events: fix doc typo and remove empty lines
- kernel: events: add function to clear events
- Bluetooth: Audio: Replace generic media "send cmd" with explicit commands
- Bluetooth: Audio: Add missing `static` for MCC shell commands
- Bluetooth: Audio: Removed unused cmd_mcc_ots functions
- logging: minimal: Change imply to select for printk
- drivers: regulator: pca9420: use standard I2C API
- dsp: move cmsis_dsp basicmath tests
- math: Introduce a DSP basicmath subsystem with a cmsis backend
- dsp: Update tests for basicmath to use dsp subsystem
- gpio: add `gpio_is_ready_dt` function
- posix: getopt: move declarations to unistd.h
- soc: atmel_sam: add support for SAM E70 q19 parts
- drivers: regulator: cleanup device_is_ready and atoi usage
- drivers: regulator: support for regulator mode APIs in regulator shell
- settings: put all options under `if SETTINGS`
- settings: line: fix typos in comments
- settings: line: remove unused MAX_ENC_BLOCK_SIZE macro
- settings: line: simplify settings_line_len_calc()
- settings: file: remove unnecessary drop of const identifier
- settings: fcb: remove unnecessary drop of const identifier
- lib: newlib: Define _ANSI_SOURCE
- arch/arm64: Support runtime frequency
- cmake: update FindDeprecated for SOURCES
- boards: mimxrt595evk: Setup the regulator for Run mode
- tests: devicetree: device: Add mimxrt595_evk_cm33 exclusion
- drivers: serial: uart_xmc4xxx: Fix write to fifo with more than one byte
- shell: devmem: add devmem dump subcommand
- sample/drivers/jesd216: spi-nor config for nrf52840dk
- assert: Add no-op stub for __ASSERT_POST_ACTION
- tests: kernel: fifo_timeout: Correct misleading error message
- tests: kernel: fifo_timeout: Do not print status messages during tests
- drivers: entropy: PSA crypto RNG driver default
- dts: bindings: reset: add binding for Aspeed AST10x0 reset
- drivers: reset: add Aspeed AST10x0 reset control
- dts: arm: aspeed: add AST10X0 system reset control
- boards: arm: ast1030_evb: enable reset driver
- samples: jesd216: fix integration platforms
- settings: file: do not create file when loading
- drivers: pwm: mcux: ftm: fix pwm capture timer overflow count edge cases
- soc: esp32x: replace STATUS by int
- soc: esp32: set RTC registers to known state
- boards: esp32_net: ignore PM tests
- pm: esp32: system power management
- soc: esp32s2: set RTC registers to known state
- pm: esp32s2: system power management
- soc: esp32c3: set RTC registers to known state
- pm: esp32c3: system power management
- esp32: samples: power management: add deep sleep sample
- doc: services: pm: add reference to esp32 sample
- boards: xtensa: esp32: dts: add power states
- boards: xtensa: esp32s2_saola: dts: add power states
- boards: riscv: esp32c3_devkitm: dts: add power states
- soc: esp32: add light sleep sample code
- west: hal_espressif: update revision
- fs/fatfs: Add CONFIG_FS_FATFS_MIN_SS
- doc/release: Add note on addition of CONFIG_FS_FATFS_MIN_SS
- shell: Fix log message queue size for all backends
- mgmt/mcumgr: Remove redundant config headers
- ipc: ipc_service: kconfig cleanup
- shell: shell_log_backend: added check for msg allocation
- fs: Add fs_mkfs operation to fs api
- fs: Implement mkfs operation in littleFS
- fs: Implement mkfs operation in FAT fs
- samples: fs: Add sample using fs_mkfs function
- doc: release-notes: add file systems notes
- tests: fs: Add test of fs_mkfs
- Bluetooth: controller: CIS Central fixes
- drivers: usb_dc_nrfx: Do not uninit on detach
- i2c: add i2c_is_ready_dt function
- mgmt/mcumgr: Remove APP_LINK_WITH_MCUMGR Kconfig option
- doc/releases: Add note on removal of CONFIG_APP_LINK_WITH_MCUMGR
- tests/mgmt/mcumgr/smp_reassembly: Correct zassert messages
- fs/fat: Improve help of Kconfig options for FAT
- drivers: usb: usb_dc_nrfx: add usbd worker thread name.
- samples: shields: npm6001_ek: fix build
- arch: arm64: timer: Add missing inclusion of limits.h
- dts: arm: stm32h723 add CAN2 and CAN3
- toolchain: Replace GCC_VERSION, CLANG_VERSION and BUILD_ASSERT macros
- drivers: ethernet: stm32: check tx packet size before locking mutex
- drivers: ethernet: stm32: use modified hal_stm32 manifest
- drivers: ethernet: stm32: Add Kconfig to select new HAL API
- drivers: ethernet: stm32: Additional structures for new HAL driver
- drivers: ethernet: stm32: Make tx semaphore available for new api
- drivers: ethernet: stm32: Disable autonegation for new api
- drivers: ethernet: stm32: Add receive callbacks
- drivers: ethernet: stm32: Add transmit callbacks
- drivers: ethernet: stm32: Add Error Callback
- drivers: ethernet: stm32: Enable transmitting with new driver
- drivers: ethernet: stm32: Transmit frames larger than one buffer
- drivers: ethernet: stm32: Enable receiving with new driver
- drivers: ethernet: stm32: initialization routine for the new driver
- shell: support setting help string for each entry in a dictionary command
- drivers: regulator: pca9420: refactor mode handling
- soc: rt1xxx: allow linking code to OCRAM region
- soc: rt11xx: Enabled multicore support with second image
- dts: nxp_rt11xx: Refactored RT11xx CM7 and CM4 DTS
- drivers: ipc: Enable messaging unit driver for iMX.RT multicore SOCs
- soc: nxp_imx: Add code to wait for second core boot in RT11xx
- dts: nxp_imx: Add zephyr,memory-region attribute to memory regions
- boards: mimxrt1170_evk: Refactor flexspi partition definition
- boards: mimxrt1170_evk: add support for loading M4 image from OCRAM
- boards: mimxrt1170_evk: enable messaging unit
- boards: mimxrt1170_evk: Enable LED1 node
- samples: ipc: openamp: Enable openamp sample for iMX.RT1170 EVK
- boards: mimxrt1170_evk: Update RT1170 documentation for dual core support
- boards: mimxrt1160_evk: Refactor flexspi partition definition
- boards: mimxrt1160_evk: add support for loading M4 image from OCRAM
- boards: mimxrt1160_evk: enable messaging unit
- samples: ipc: openamp: Enable openamp sample for iMX.RT1160 EVK
- boards: mimxrt1160_evk: Update RT1160 documentation for dual core support
- net: buf: Simplify fragment handling
- bluetooth: mesh: Remove illegal use of NET_BUF_FRAG in friend.c
- ztest: Add config to control test summary
- tests: settings: file: remove declarations of ZTEST() routines
- gpio: fix the nct38xx driver
- gpio: add support for get_config and get_direction in nct38xx
- gpio: cleanup the nct38xx driver
- drivers: clock_control: some stm32 have a HSI48 fixed clock
- drivers: stm32: do not enable the HSI48 locally
- include: bindings: stm32 clock HSI48 defined
- dts: arm: stm32 devices with hsi48 clock
- boards: arm: nucleo_wb55rg enables hsi48 for Bluetooth
- boards: arm: enabling hsi48 for RNG peripheral on stm32 platforms
- boards: arm: enabling hsi48 for USB peripheral on stm32 platforms
- boards: arm: enabling hsi48 for SDMMC peripheral on stm32 platforms
- boards: arm: Add adafruit_itsybitsy_nrf52840 board
- Bluetooth: doc: Note on thread safety
- drivers: lpuart: enable rs485 mode
- doc: mgmt: mcumgr: Clarify sha256 hash details in img_mgmt
- doc: release: 3.3: Add change on MCUmgr img_mgmt hash
- drivers: spi: esp32xx: Fix buffer length for DMA
- Bluetooth: controller: corrected time stamps for unframed RX
- tests: Bluetooth: controller: corrected input PDU time stamps
- tests: settings: remove passing -DTEST_${TEST} from cmake
- spsc_pbuf: Fix cache wb in spsc_pbuf_free
- settings: file: Fix flash area erase offset
- modules: lvgl: Enable for CPU_CORTEX_M0/M0PLUS
- zdsp: Fix missing kconfig and no source library
- drivers: gsm_ppp: replace DT_INST with DT_DRV_INST
- Bluetooth: controller: proper handling of invalid pdu in CIS create
- fs: fat: document path transformation
- gitlint: Add "commit" to violation messages
- mgmt: mcumgr: lib: cmd: os: Add device information handler
- doc: mgmt: smp group 0: Add OS info details
- doc: release: 3.3: Add os_mgmt info command
- tests: mgmt: mcumgr: os_mgmt_info: Add tests
- mgmt: mcumgr: transport: dummy: Fix issue with large packets
- doc: board porting: Add clarifications
- boards: riscv: longan_nano: add configuration for LCD
- drivers: counter: Add __fallthrough in STM32 counter driver
- dts: xtensa: intel: update cavs25_tgph to match cavs25
- spi: add spi_is_ready_dt function
- drivers: tests: replace usage of `spi_is_ready` with `spi_is_ready_dt`
- drivers: spi: deprecate `spi_is_ready` function
- soc: arm: microchip: mec172x: Correct PECI base address
- drivers: bbram: Introduce STM32 BBRAM driver
- drivers: bbram: Introduce BBRAM shell
- dts: arm: st: f0: Add RTC BBRAM to DTS
- dts: arm: st: f2: Add RTC BBRAM to DTS
- dts: arm: st: f3: Add RTC BBRAM to DTS
- dts: arm: st: f4: Add RTC BBRAM to DTS
- dts: arm: st: f7: Add RTC BBRAM to DTS
- dts: arm: st: h7: Add RTC BBRAM to DTS
- dts: arm: st: l0: Add RTC BBRAM to DTS
- dts: arm: st: l1: Add RTC BBRAM to DTS
- dts: arm: st: l4: Add RTC BBRAM to DTS
- dts: arm: st: wb: Add RTC BBRAM to DTS
- boards: arm: Enable RTC backup RAM on some boards
- tests: drivers: bbram: Test BBRAM on STM32 devices
- boards: arm: nucleo l4r5zi enables HSI48 clock for USB
- tests: re-enable tests which were disabled due to ARC QEMU issues
- tests: settings: fcb: remove local test_config_insert{2,3} prototypes
- tests: settings: fcb: remove unused zephyr/sys/printk.h
- tests: settings: nvs: remove unused settings handlers
- tests: settings: file: remove unused c2_var_count
- Revert "drivers: gpio: STM32U5 independant IO supply"
- dts: arm: stm32h723 add USB OTG HS
- drivers: usb: stm32: Simplify Kconfig help message
- boards: arm: nucleo_h723zg enable USB
- tests: settings: remove unused settings_enc.c
- shields: add Semtech SX1262MB2DAS
- drivers: dma: stm32u5 do not reset the dma channel when suspending
- drivers: dma: stm32u5 dma with resume API function
- drivers: gpio: add driver for nuvoton numicro
- dts: arm: numicro_m48x: add gpio nodes
- west.yml: update hal_nuvoton revision to add pinctrl include file
- drivers: pinctrl: add numicro pinctrl driver
- drivers: serial: numicro: use pinctrl instead of hard-coded values
- drivers: serial: numicro: fix poll_in function
- boards: arm: nuvoton_pfm_m487: fix incorrect shell uart alias
- boards: arm: nuvoton_pfm_m487: use gpio and pinctrl apis by default
- xtensa: linker: Fix #52539 by updating the linker scripts
- lib: libc: Clean up CMake script to use add_subdirectory_ifdef
- lib: libc: Move minimal libc configs to lib/libc/minimal/Kconfig
- lib: libc: Move newlib libc configs to lib/libc/newlib/Kconfig
- lib: libc: picolibc: Clean up Kconfig configurations
- drivers: dma: Simplify stm32_dma_check_fifo_mburst() function
- fs: Improve documentation for fs_mkdir
- Bluetooth: Mesh: Call friendship callbacks at the end
- Bluetooth: Mesh: Calculate adv duration instead of using estimation
- Bluetooth: Mesh: Warn log mode incompatibility with friendship
- net: zperf: fix incorrect statistics of zperf
- tests: bluetooth: tester: allow to add more CCCs
- Bluetooth: controller: Fix LL_CIS_TERMINATE RX node leak
- Bluetooth: controller: Fix error in ISO reset sequence
- Bluetooth: controller: Reject CIS_REQ with invalid PHY
- Bluetooth: controller: Fix CIS restart state de-initialization
- Bluetooth: controller: Don't consider CIS connected before established
- Bluetooth: controller: Fix ISO Test Mode SDU counting for framed
- Bluetooth: controller: Minor ISO refactoring due to compiler issue
- Bluetooth: controller: Add handle to ll_data_path_sink_create
- Bluetooth: controller: Reject CIS_TERMINATE when unsupported for role
- Bluetooth: controller: refactor ll_rx_put/sched
- Bluetooth: controller: refactor ull_rx_put/sched
- Bluetooth: controller: refactor enc setup lll function
- Bluetooth: controller: refactor to remove duplicated state function
- Bluetooth: controller: refactor pdu encode/decode functions
- Bluetooth: controller: refactor conn update notify function
- Bluetooth: controller: refactor to remove duplicated functionality
- kernel: Kconfig: Increase the main stack size for ARM when TEST
- logging: Fix case when LOG_LEVEL is 0
- drivers: reset: Introduce STM32 reset controller
- dts: arm: st: f0/f1/f3: Add reset controller node
- dts: arm: st: f2/f4/f7: Add reset controller node
- dts: arm: st: h7: Add reset controller node
- dts: arm: st: g0: Add reset controller node
- dts: arm: st: g4/l4/l5: Add reset controller node
- dts: arm: st: l0: Add reset controller node
- dts: arm: st: l1: Add reset controller node
- dts: arm: st: u5: Add reset controller node
- dts: arm: st: wb/wl: Add reset controller node
- drivers: reset: Add support for reset clear register
- dts: arm: st: mp1: Add reset controller node
- dts: Introduce 'resets' property for STM32 timer nodes
- drivers: counter: Reset timer using RCC before initialization
- dts: Introduce 'resets' property to STM32 UART nodes
- drivers: serial: Reset UART using RCC before initialization
- samples: Use immediate logging mode in watchdog related samples
- doc: Move Flash Img API under Device Management
- dfu/mcuboot: Add Doxygen group to mcuboot.h
- doc/dfu: Add MCUboot API chapter to documentation
- drivers: i2c_nrfx_twi[m]: Make transfer timeout value configurable
- drivers: ivshmem: remove unnecessary platform dependency
- drivers: ivshmem: msi.h header only required for ivshmem-doorbell
- drivers: pcie: late initialization of pcie when PCIe controller is used
- dts: qemu: a53: kvm: add DTS support for PCIe controller
- tests: drivers: virtualization: move ivshmem test to a new folder
- tests: drivers: virtualization: remove MSI dependency from sample
- tests: drivers: virtualization: enable QEMU ARM64 support for ivshmem-plain
- include: arch: arm64: limits header needed for ASSERT
- tests: drivers: virtualization: enable KVM support for ivshmem-plain
- dts: bindings: pcie: update interrupt-map type to compound
- Bluetooth: Controller: Fix BT_LL_SW_LLCP_LEGACY compile error
- driver: gpio: Fixing Pin Direction Setting.
- driver: dw: Use base_addr variable to set dir.
- soc: gd32f4xx: correct typo
- drivers: clock_control: gd32: Correcting timer node detection
- drivers: clock_control: gd32: timer should recognize with entire id
- drivers: counter: add support for GD32 timer
- boards: arm: gd32: Add support for counter device
- tests: counter: counter_basic_api: add support for GD32 boards
- samples: counter: alarm: add support for GD32 boards
- arch: aarch32: add caches capability to Cortex-R52
- Soc: arm: enable I/D-caches at NXP S32Z/E SoC
- arch: support nocache for Cortex-R52
- arch: update alignment for Cortex-R52
- arm: aarch32: config static regions with MPU disabled
- soc: arm: refactor MPU region for NXP S32Z/E
- drivers: interrupt_controller: Add XMC4XXX ERU driver
- drivers: gpio_xmc4xxx: Use interrupt controller for edge/level interrupts
- drivers: wifi: eswifi: Guard net_ctx state change
- Bluetooth: audio: fix invalid ase state transition
- Bluetooth: audio: tbs_client: Fix misleading error log
- boards: riscv: add Seeed Studio xiao_esp32c3
- net: l2: ethernet: ethernet support for AF_PACKET/SOCK_RAW/IPPROTO_RAW
- sample: usb: shell: add keybord harness string
- drivers: flash: spi_nor: release notes for fix flash busy during init
- tests/mcumgr/zcbor_bulk: Add test for map in map decoding
- tests/mcumgr/zcbor_bulk: Add additional test platforms
- arc: add XY mem support
- include: drivers: adc: Refactor the ADC_CHANNEL_CFG_DT() macro
- usb: device: update logging module registration
- dts: riscv: gd32vf103: Correct wrong clock configuration for `dma1`
- drivers: sensor: bmm150: fix mispelling
- drivers: serial: Add Driver for CDNS UART IP6528
- openamp: Add new Kconfig option to enable dcache
- Bluetooth: Controller: Fix missing cssn and cstf flag initialization
- Bluetooth: Controller: One extra ISO rx buffer for empty PDU reception
- Bluetooth: Controller: Fix Broadcast ISO PDU receive connection handle
- Bluetooth: Controller: Fix BIS subevent channel indices
- Bluetooth: Controller: Receive starting at selected BIS and skip others
- Bluetooth: Controller: Add internal comments in BIS LLL code
- Bluetooth: Controller: Fix dynamic tx power for Broadcast ISO
- Bluetooth: Controller: Remove duplicate code in nRF5 radio HAL
- Bluetooth: Controller: Fix MIC failure transmitting LL_CIS_REQ PDU
- drivers: gpio: stm32: Keep port clock in input configuration
- i3c: rename is_primary to is_secondary
- i3c: add write to tx fifo target api
- i3c: fix macro generation with multiple devices
- i3c: add NBCH header flag for private transfers
- i3c: GETMWL and GETMRL may be optionally supported if no settable limit
- i3c: add cdns i3c driver
- tests: drivers: build_all: add build for i3c_cdns
- maintainers: remove obsolete self
- scripts: compliance: Fix misdetection of Kconfig choices as undefined
- samples: Use immediate logging mode in nvs sample
- tests/benchmarks: Add userspace scheduling benchmark
- arch/arm64: Implement ASID support in ARM64 MMU
- ipc: static_vrings: Zero config struct
- drivers: gicv3: add zephyr kernel header file
- samples: blinky_pwm: Add nucleo_l476rg support
- fuel_gauge: Fix sbs_gauge err to conform to API
- mgmt/mcumgr: zcbor_bulk: Allow spaces in map keys
- tests/mgmt/mcumgr/zcbor_bulk: Use ZCBOR_MAP_DECODE_KEY_DECODER
- samples/smp_svr: Switch to ZCBOR_MAP_DECODE_KEY_DECODER
- boards: nucleo_g0b1re: enables HSI48 clock for USB
- ci: doc-build: Increase PDF documentation build timeout
- ci: doc-build: Disable PDF documentation build for pull requests
- dts: arm: stm32g0 has a APB peripheral bus clock on 2 registers
- tests: drivers: stm32g0 clock control  with APB1_2 RCC register
- drivers: dac: esp32: Add support for DAC controller
- samples: board: esp32: DAC sample code
- tests: dac: esp32: API test for CI
- manifest: update hal espressif
- cache: Fix the doxygen documentation
- cache: Add documentation
- manifest: FAT FS module version upgrade to 0.15
- fs/fatfs: Update FAT FS support code for version 0.15 w/patch1
- doc/release: Add note on FAT driver update to 0.15
- tests: settings: file_littlefs: move prototype to header file
- tests: settings: file_littlefs: fix comment about LittleFS
- tests: settings: file_littlefs: relax dependency on LittleFS
- tests: settings: file: merge file_littlefs
- tests: ARC: MWDT: allow allow-cpp.libcxx.arcmwdtlib for all arc targets
- boards: arm: Introduce Google Dragonclaw Development Board
- dma: Add max block count attribute
- mec172xmodular_assy6930: add board support
- ITE soc/it8xxx2/linker: add sections for hw sha256 calculation
- net: lib: lwm2m: add uCIFI LPWAN object
- drivers: hwinfo: Implement hwinfo_get_device_id for ESP32-C3
- tests: drivers: udc: fix uninitialized variable and thread
- drivers: udc_nrf: dequeue instantly when endpoint is not busy
- drivers: udc: do not call driver's dequeue on empty fifo
- usb: device: cdc_acm: send more than 1 byte in poll out
- settings: do not panic on backend initialization errors
- settings: file: drop CONFIG_SETTINGS_FILE_DIR
- sample: Bluetooth: Add PA interval check in iso broadcast benchmark
- log_core: Add Kconfig symbol for init priority
- shell: added SHELL_AUTOSTART configuration option
- nrf52_bsim: Add option to delay CPU and test initialization
- nrf52_bsim: Expand some bs_tests hooks descriptions
- drivers: regulator: improve regulator_count_voltages specs
- drivers: regulator: drop regulator_count_modes
- drivers: regulator: improve regulator_list_voltages
- drivers: regulator: provide generic regulator_is_supported_voltage
- drivers: regulator: clarify regulator_set_voltage
- drivers: regulator: drop mode specific APIs
- drivers: regulator: improve regulator_get_voltage
- drivers: regulator: clarify regulator_set_mode interface
- drivers: regulator: improve regulator_get_current_limit
- drivers: regulator: clarify regulator_set_current_limit()
- drivers: regulator: add regulator_mode_t opaque type
- drivers: regulator: pca9420: some minor improvements
- drivers: regulator: fix/improve usage of devicetree properties
- drivers: regulator: add parent DVS API
- drivers: regulator: add regulator_is_enabled
- drivers: regulator: add common init enable API
- drivers: regulator: add API to read error flags
- Bluetooth: GATT: Fix missing endianess conversion on include end-handle
- tests: fat_fs_api: Conditionally compile MKFS test
- dts: vendor-prefixes: Add hzgrow prefix
- drivers: sensor: Add support for grow_r502a fingerprint sensor
- samples: sensor: Added sample for grow_r502a fingerprint sensor
- tests: drivers: build_all: sensor: Add grow_r502a fingerprint sensor
- tests: spin lock timeout test spin time
- Bluetooth: Host: Add length values to malformed adv data warning
- Bluetooth: Host: Fix issue with setting 0/NULL data for PA
- dts: bindings: serial: smartbond: Fix baudrates
- scripts: migrate_includes: add .hpp to extension list
- doc: application development: fix DT overlay section
- Bluetooth: Audio: Shell: Fix issue with restarting start_sine
- Bluetooth: Audio: Shell: Improve printing of incoming audio
- Bluetooth: Audio: Remove newlines from HAS log statements
- Bluetooth: host: make HCI fragmentation async
- Bluetooth: host: poll on CTLR buffers instead of host TX queue
- Bluetooth: host: copy fragment data at the last minute
- Bluetooth: host: update l2cap stress test
- usb: device: cdc_acm: Prevent recursive logging loop
- drivers: usb: stm32: add usb hs ulpi support
- manifest: update hal_stm32
- boards: stm32h747: add usb otg hs and ulpi phy definition
- Bluetooth: audio: ascs: Handle CIS failed to be established error
- drivers: flash: clear stm32 status register errors
- samples: net: sockets: net_mgmt: Update flash requirement for twister
- net: zperf: Fix SO_RCVTIMEO dependency
- drivers: esp32: temp: CPU die temperature sensor
- samples: esp32: temp: CPU die temperature sample
- manifest: update hal espressif
- ace: dts: gpdma: add power domain
- drivers: gpdma: enable runtime power mgmt in intel gpdma
- random: Clarify the semantics of TEST_RANDOM_GENERATOR
- random: Fix non-random number generator warning condition
- hardening: Require CONFIG_TIMER_RANDOM_GENERATOR=n
- pm: runtime: Migrate from condition variables to events
- pm: runtime: Move from mutexes to semaphores
- intel_adsp: remove ace_v1x-regs.h file
- modules: lvgl: change mentions of "LittleVGL" to "LVGL"
- soc: arm: nxp: switch imxrt boards to use systick timer unless CONFIG_PM=y
- boards: arm: update documentation for imxrt to reflect use of systick
- MAINTAINERS: add an entry for google_* boards
- drivers: regulator: initial driver for nPM6001
- boards: npm6001_ek: add regulator entries
- samples: shields: npm6001_ek: add utility to test regulators
- bluetooth: controller: Reduce user ops status to uint8_t
- ace: dts: hda: add power domain
- drivers: hda: enable runtime power mgmt in intel hda dma
- Bluetooth: Shell: Add pa_interval scan filter
- samples: Bluetooth: ISO broadcast receiver pa_interval check move
- Bluetooth: Shell: Move the name filter last
- include: drivers: add USB host controller (UHC) driver API header
- drivers: usb: add common layer of UHC API and MAX3421E driver
- shields: add Sparkfun MAX3421E shield support
- usb: add initial USB host support
- drivers: usb: add support for virtual USB bus
- drivers: udc: add driver for virtual USB device controller
- drivers: uhc: add driver for virtual USB host controller
- samples: usb: shell: extend new USB support sample by host support
- include: usb_hub: add macros for the USB hub class
- usb: host: add port power and port reset USB hub features
- tests: settings: fcb: increase ztest stack size to 2kB
- tests: settings: functional: file: increase ztest stack size to 2kB
- tests: settings: file: increase main stack size to 2kB
- tests: settings: enable ARM MPU
- tests: settings: remove explicit CONFIG_STDOUT_CONSOLE=y
- tests: settings: functional: remove per platform prj_*.conf
- drivers: usb_dc_stm32: implement usb_dc_wakeup_request
- Bluetooth: Audio: Shell: Add EATT to audio.conf
- Bluetooth: Audio: Shell: Add support for more connections
- Bluetooth: Audio: Shell: Enable optional TBS features
- Bluetooth: Audio: Shell: Add TBS Client debug logging in audio.conf
- nxp_imx: fix base address of Flexspi2
- intel_adsp: boot: allow boot from imr without restore
- boards: degu_evk: disable CDC ACM logging
- intel_adsp: dai: Add support for ALH streams 2 and 3
- drivers: hwinfo: stm32: Deal with iwdgX and wwdgX instances
- tests: time_units: check for overflow in z_tmcvt intermediate
- Bluetooth: host: adv: add `adv_is_directed` helper
- Bluetooth: host: add bsim test for #52059
- Bluetooth: host: adv: set the address in bt_le_adv_resume
- Bluetooth: audio: correct arg usage in BT_CODEC_LC3_CONFIG_DATA
- ITE: drivers/espi: fix the VW valid flag issue in MAFS mode
- pm: don't suspend unready devices when entering low power states
- shell: Clear command buffer when leaving bypass mode
- net: shell: Make it possible to abort ping command
- boards: arm: stm32f3_seco_d23: Add SECO JUNO SBC-D23 board
- Bluetooth: Test: Mesh: change mesh shell test log mode
- boards: bl654_usb: disable CDC ACM logging
- cmake: extensions: clarify zephyr_file() behavior
- cmake: modules: extensions: fix a section header
- cmake: shields: documentation fixes
- DSP: add DSP support for ARC processor
- arc: add nsim_em11d target
- DSP: add dsp unit test
- mgmt: mcumgr: Replace non-zephyr cmake functions with zephyr versions
- cmake: fix the wrong arg name when calling check_zephyr_package()
- tests: bluetooth: mesh: Update BT_MESH_LPN_RECV_DELAY default value
- dts: stm32: f302: reset property missing from tim4 node
- boards: riscv: hifive1: add arduino_header configuration
- settings: fcb: remove second settings_fcb_storage_get() prototype
- settings: remove local settings_mount_*_backend()
- drivers: nrf_qspi_nor: Avoid using QSPI with HFCLK192M divided by 4
- boards: arm: stm32g081b_eval: Add ADC1 Channel9
- boards: arm: stm32g081b_eval: Add UCPD1 peripherals to dts node
- boards: arm: stm32g081b_eval: Add PWM15 peripherals to dts node
- Bluetooth: Audio: Fix issue with non-bonded devices in has.c
- Bluetooth: Audio: Fix logging of object ID in mcc.c
- Bluetooth: Audio: Always start BAP discovery at handle 0x0001
- drivers: flash: stm32: Kconfig clean up
- Bluetooth: ISO: Fix `conn_mtu` for BT_CONN_TYPE_ISO
- Bluetooth: ISO: Fix ISO MTU when CONFIG_BT_BREDR=y
- drivers: gpio: narrow single ended mode assertion
- net: l2: bluetooth: Remove invalid check
- net: if: Allow to set LL address after interface was brough admin UP
- net: l2: ieee802154: Align LL address update routine
- sensor: amg88xx: fix sensor sample
- boards: arm: bl654_usb: Fix USB CDC enablement with MCUboot
- Bluetooth: Host: Add logging of pairing req/rsp
- drivers: usb_c: tcpc: stm32: Read UCPD Status Reg for source of IRQ
- drivers: usb_c: tcpc: stm32: Simplify shared ISR detection
- drivers: usb_c: tcpc: stm32: Enable ISR after all UCPD devices initialized
- drivers: usb_c: tcpc: stm32: Add GoodCRC timer
- drivers: usb_c: tcpc: stm32: Explicitly set the unconnected CC line to OPEN
- drivers: usb_c: tcpc: stm32: Add VCONN functionality
- dts: binding: add cortex-a55 dts binding
- soc: arm64: add i.MX93 MPU support
- board: arm64: add imx93 evk board support
- drivers: mcux_lpuart: remove unsed soc.h
- drivers: mcux_lpuart: fix compile warning
- drivers: mcux_ccm: add support for lpuart on imx93
- drivers: pinctr_imx: add imx93 support
- board: arm64: add pinctrl support for imx93 evk board
- boards: arm64: add mimx93 evk board document
- codeowners: add entry for arm64 board mimx93_evk
- west.yml: depend on hal PR 213
- Bluetooth: Audio: Endpoint: Decouple Client and Server
- Bluetooth: Audio: ASCS: Make ASE Allocation Dynamic
- Bluetooth: Audio: Remove const for bt_audio_stream_reconfig codec
- Bluetooth: Audio: Add broadcast source metadata update function
- Bluetooth: Audio: Move common broadcast sink test code to function
- Bluetooth: Host: Fix missing pull left mem in scan pdu
- dts: bindings: regulator: drop regulator-coupled* properties
- drivers: regulator: common: fix is_supported_voltage comparison
- drivers: regulator: fix is_supported_voltage return code
- drivers: regulator: fix REGULATOR_DT_COMMON_CONFIG_INIT
- drivers: regulator: fix set_voltage limits check
- drivers: regulator: fix set_current_limit limits check
- drivers: regulator: add fake driver
- drivers: regulator: add typedefs for API ops
- tests: drivers: regulator: api: test API behavior
- mgmt/mcumgr: Remove inclusion of mgmt.h from smp/smp.h
- mgmt: mcumgr: Make returning rc responses when status is OK legacy
- doc: release: 3.3: Add note for legacy mcumgr rc responses
- doc: device_mgmt: smp: Update rc documentation
- boards: arm: nordic nrf91* nrf53* nrf52* nrf51*: Remove scratch areas
- tests: subsys: settings: Remove nrf52 scratch
- tests: subsys: dfu: Remove nrf52 scratch
- doc: release: 3.3: Add note on Nordic board scratch changes
- manifest: MCUboot upgrade
- devicetree: add virtual memory entry for intel platform
- memory manager: refactor
- memory manager: add region calculation for virtual memory
- soc: arm: infineon_xmc: Set include headers via xmc_device.h
- drivers: adc: Add ADC xmc4xxx drivers
- tests: adc_api: Add xmc45_relax_kit config
- samples: drivers: adc: Add xmc45_relax_kit overlay
- manifest: MCUboot upgrade
- scripts: ci: compliance: Remove Codeowners check
- Bluetooth: has: Make HAS registration dynamic
- Bluetooth: Mesh: Add macros to initialize bt_mesh_msg_ctx struct
- net: websocket: new receiving algorithm
- dts: bindings: usb stm32: Remove deprecated prop 'enable-pin-remap'
- boards: arm: adafruit_itsybitsy_nrf52840: Standardise on USB CDC name
- tests: drivers: regulator: add voltage levels test
- tests: regulator: pca9420: remove driver specific test
- west.yml: hal_silabs: update hal version
- soc: arm: silabs: remove soc_gpio_configure wrapper
- drivers: pinctrl: Add Silabs Gecko pin controller
- drivers: serial: uart_gecko: Make driver dependent on pinctrl
- drivers: counter: Add counter_gecko_stimer driver
- samples: drivers: counter: support alarm sample in counter_gecko_stimer
- tests: drivers: counter: counter_basic_api support in counter_gecko_stimer
- drivers: gpio: gecko: initialize driver earlier
- drivers: gpio: gecko: enable GPIO clock
- soc: silabs_exx32: Add support for SiLabs EFR32BG22 SoC
- boards: Add support for Silicon Labs EFR32BG22-SLTB010A board
- dts: arm: silabs: efr32mg21: update peripheral reg addresses
- drivers: gpio: gecko: stop using deprecated function
- drivers: hwinfo: Fix Gecko hwinfo driver building
- drivers: watchdog: silabs: include zephyr/irq.h
- dts: gpio: silabs: make peripheral-id optional
- dts: uart: silabs: make peripheral-id optional
- drivers: timer: stm32_lptim: load counter after checking for autoreload
- ARC: introduce reworked irq_offload implementation
- clang-format: Enable InsertBraces option
- twister: Allow passing additional args to native_posix test binary
- all: Fix "#if IS_ENABLED(CONFIG_FOO)" occurrences
- include: util_macro: Advise not to use IS_ENABLED in #if directives
- tests: drivers: regulator: refactor fixed regulator test
- dts: SHA: npcx: add the SHA DTS node and binding
- drivers: crypto: SHA: npcx: add support for SHA hardware accelerator
- boards: arm: thingy53: Enable USB-CDC for console
- tests: kernel: timer: starve: Adjust timeout value
- ace: dts: gpdma: add third controller
- drivers: uart_nrfx_uarte: Prevent re-enabling RX until UART_RX_DISABLED
- include: zephyr: dt-bindings: clock: Add separate clock file for STM32F7
- dts: arm: st: f7: Use new dedicated clock file for STM32F7
- dts: arm: st: Add default I2C clock source for STM32F0 & F3
- drivers: i2c: Use dts to determine i2c clock source for STM32
- doc: contribute: drop the point about subsystem branches
- doc: contribute: add a note about the GitHub "Update branch" feature
- driver: uart: npcx: add missing tx/rx interrupt enabled checks
- drivers: gpio: sifive: Reset iof_en and iof_sel on init
- drivers: usb_c: Properly detect a disconnect while operating as a Source
- usb: device: hid: correct bcdHID to v1.11 spec
- modules: openthread: platform: Added setting default tx power
- boards: Swan DeviceTree Inheritence
- logging: backend_uart: Reword buffer size Kconfig text
- tests: fat_fs_api: MKFS still causing build errors
- drivers: eth: gecko: fix GPIO configuration
- Bluetooth: Audio: Fix audio_iso handling for unicast client
- Bluetooth: Audio: Fix issue with creating the CIG as unicast client
- Bluetooth: ISO: Remove wrong requirement for cc_len
- Bluetooth: Audio: Fix unicast group add/free handling of endpoints
- Bluetooth: Audio: Fix handling properly deleting endpoints
- boards: riscv: hifive1: add openocd configuration
- include: fs: Remove conditional around MKFS
- cmake: fix a typo in zephyr_linker_arg_val_list() macro
- boards: arm: mec172xevb: add cpu-power-states property
- boards: riscv: Add support for SparkFun RED-V Things Plus
- drivers: uart_mcux_flexcomm: Add runtime configure
- mcuboot: doc: Define MCUBOOT_EXTRA_IMGTOOL_ARGS more clearly
- manifest: hal_nxp: Replace PR with SHA
- cmake: log ${CMAKE_VERSION}
- Kconfig.zephyr: Update UF2 ID for STM32F4 series
- drivers: clock_control: stm32: Use zephyr functions for bit operations
- Bluetooth: Audio: Add packing field to broadcast source
- Bluetooth: Audio: Add packing to unicast group create
- hal_espressif: remove base64 redefinition
- pinctrl_stm32: GPIO output info in Z_PINCTRL_STM32_PINCFG_INIT
- mgmt: mcumgr: Add iterable section to register MCUmgr handlers
- doc: release: 3.3: Add note on MCUmgr handler update
- mgmt: mcumgr: Make handler registration functions static
- mgmt: mcumgr: Make Bluetooth and UDP transport init automatic
- doc: release: 3.3: Add note on MCUmgr handler update
- samples: boards: nrf: mesh: onoff: Remove MCUmgr files
- samples: drivers: adc: fixup ADC sample support for LPADC
- net: zperf: Define a public upload API for the library
- net: zperf: Implement asynchronous upload API
- net: zperf: Add shell option for asynchronous upload
- net: zperf: Add public API to start TCP/UDP server
- net: zperf: Make UDP/TCP servers restartable
- net: zperf: Add shell command to stop TCP/UDP server
- net: zperf: Shell cleanup
- net: zperf: Simplify shell initialization
- drivers: gpio: fix gpio-reserved-ranges handling in MCUX iGPIO driver
- drivers: espi: enable ESPI_EMUL automatically
- tests: uart: Test pushing more than 1 byte in uart_fifo_fill call
- boards: arm: rtxxx: moving the instances FLASH_MCUX_FLEXSPI_XIP
- soc: arm: nxp_imx: replaced CODE_LOCATION and added FLEXSPI_XIP to soc
- ipc: Enable ICMSG multiendpoint role by default
- ipc: icmsg capability to clear rx buffer headers
- ipc: icmsg: rx nocopy feature
- ipc: icmsg: send nocopy feature
- ipc: icmsg multi endpoint with nocopy in send path
- ipc: icmsg multi endpoint with nocopy in receive path
- samples: ipc: icmsg_me: use nocopy functions
- mcumgr: img_mgmt: Add SHA256 image upload hash check
- logging: Add an option for a custom log header
- mgmt/mcumgr: Standardise MCUmgr Kconfig names
- doc: MCUmgr replaced Kconfig options to new format
- scripts/utils/migrate_mcumgr_kconfigs.py: Script for migrating MCUmgr
- mgmt/mcumgr: Move Kconfig options to proper Kconfig files
- mgmt/mcumgr: Add Kconfig option naming notes
- doc/release: Add notes on MCUmgr Kconfig renames
- tests: dma: loop_transfer: Correct DMA definition of gd32f350r_eval
- drivers: dma: dma_gd32: Use dma_slot for peripheral request
- dts: bindings: gd32-dma: add config cell property
- dts: bindings: gd32-dma-base: add `gd,mem2mem` property
- dts: bindings: dma: gd32: split gd,gd32-dma-v1 for support F4xx feature
- tests: dma: loop_transfer: add overlay for GD32 boards
- boards: gd32: add `dma` as supported feature
- net: lwm2m: Verify receiving buffer size in lwm2m_engine_get()
- doc: develop: tools: drop platformio docs
- dts: bindings: stm32f1 clocks: Add USB/OTG prescaler on F1 PLL bindings
- drivers: clock_control: stm32f1: Configure USB prescaler
- boards: stm32f1: Check usbpre/otgfspre based on sysclk freq.
- drivers: usb: stm32f1: USB clk prescaler config done in clock_controller
- logging: fix error handling in link_filters_init
- net: lib: LwM2M rd client fix
- clang-format: enable SpaceBeforeParens option
- scripts: compliance: fix DevicetreeBindingsCheck
- scripts: compliance: move isfile() check in get_files()
- scripts: compliance: add an ImageSize check
- usb-c: Add Source Power Delivery macros
- soc: arm: infineon_xmc: 4xxx: Disable unalign trap on reset
- drivers: adc: esp32: Add support for single-shot conversion
- samples: driver: adc: Add ESP32 boards support files
- tests: adc: esp32 api test
- doc: scripts: remove legacy redirects
- doc: scripts: sort redirects alphabetically
- doc: mgmt: mcumgr: callbacks: Fix issues
- mgmt: mcumgr: img_mgmt: Fix mismatched slot missing variable
- sensor: esp32c3: fix coretemp DTS register address
- drivers: i2c: Use device tree instance for STM32 I2C driver
- drivers: i2c: Use domain clock support macro for STM32 I2C
- drivers: i2c: Fix clock value for STM32 I2C
- dts: arm: st: I2C clock source for STM32F0 & fF
- drivers: watchdog: add support for NXP S32 S32ZE
- boards: arm: s32z270dc2_r52: enable watchdog support
- boards: s32z270dc2_r52: add docs for watchdog shim driver
- tests: drivers: watchdog: add test watchdog for s32z270dc2_r52
- sysbuild: shared cache variable instead of local scope variable
- drivers: regulator: common: remove redundant cast
- tests: drivers: regulator: api: check init conditions during setup
- drivers: regulator: apply initial mode
- drivers: regulator: add get_mode API
- drivers: regulator: npm6001: add support for get_mode
- samples: shields: npm6001_ek: add support to query mode
- samples: shields: npm6001_ek: remove dead assignment
- lib: linear_range: fix count for ranges with step 0
- drivers: regulator: shell: refactor shell
- maintainers: add entry for regulator drivers
- arch: xtensa: save FPU register in context switching
- tests: kernel: fpu_sharing: add xtensa arch
- storage: flash_map: shell: Show device pointer instead of ID
- storage/flash_area: Remove unused field fa_device_id
- doc/release: Add release note on removal of fa_device_id
- MAINTAINERS: fix missing ":"
- actions: manifest: update action-manifest
- drivers: modem: gsm: fix RSSI check condition
- soc: nrf52: Kconfig option for nRF52840 anomaly 198
- drivers: adc: stm32 driver for the stm32U5 instance 1 or 4
- drivers: adc: stm32u5 adapt resolution range for ADC1 and ADC4
- drivers: adc: stm32 driver for the stm32U5 configuration for the ADC4
- dts: arm: stm32u5 serie has a vbat internal on ADC1 and ADC4
- boards: arm: enabling ADC4 on the nucleo_u575zi_q board.
- samples: sensor: vbat of the stm32u5x channel 14 on ADC4
- tests: bluetooth: host: Add UT for bt_keys_clear()
- posix: Kconfig for timer_create wait time
- tests: bluetooth: host: Add mocks for id.c
- tests: bluetooth: host: Add UT for bt_id_read_public_addr()
- drivers: regulator: shell: fix printing of first voltage
- manifest: upgrade hal_gigadevice
- soc: arm: gigadevice: add gd32l23x series
- dts: arm: gigadevice: add gd32l23x series
- drivers: pinctrl: gd32_af: add gd32l23x series
- drivers: clock_control: gd32: add gd32l23x series
- drivers: adc: gd32: adc gd32l23x series
- boards: arm: add gd32l233r_eval board
- samples: drivers: adc: add gd32l233r_eval board
- samples: basic: blinky: use gpio_is_ready_dt
- samples: basic: button: use gpio_is_ready_dt
- drivers: serial: nrfx: ifdef optional baudrates
- drivers: clock: Microchip MEC172x clock control driver support all modes
- drivers: clock: Microchip XEC clock driver add MEC15xx support
- soc: microchip_mec: Replace test clock out Kconfig with DT entry
- samples: drivers: clock_xec: Add MEC172x and MEC152x clock driver sample
- samples: mec15xxevb: pm: update test clk out config
- driver: i2c: Fix Controller Initialization
- include: sensor: helpers for milli and micro unit prefixes
- tests: sensor generic: add milli and micro conversion tests
- tests: sensor generic: fix grammar used in test messages
- drivers: sensor: Add support ICP10125 pressure and temperature sensor
- linker: make debug monitor isr symbol weak
- Kconfig: add config for low-priority debug mon isr
- samples: add debug monitor sample
- modules: build segger debugmon code with config
- doc: add monitor mode debugging entry
- tests: drivers: regulator: fixed: Standarize names of the fixture
- drivers: gpio: sx1509b: add multi-instance support
- scripts: compliance: move binding file cycle in run()
- scripts: compliance: use get_files filter for dts checks
- scripts: compliance: check for bindings in subdirectories
- cmake: armfvp: allow for extra arguments
- logging: Reset buffered message counter on init
- tests: logging: log_api: Align native posix case
- tests: lib: mpsc_pbuf: Add native_posix to allowed list
- lib: os: mpsc_pbuf: Improve debugging
- lib: os: mpsc_pbuf: Use flag for buffer full indication
- tests: lib: mpsc_pbuf: Adapt test after changes in the module
- lib: os: mpsc_pbuf: Fix concurrency issues
- tests: lib: mpsc_pbuf: Add new test case
- tests: lib: mpsc_pbuf: Add stress test
- tests: lib: mpsc_pbuf: Add qemu_x86_64
- west: runners: improve pyocd runner test coverage
- scripts: compliance: add a check for MAINTAINERS.yml format
- gpio: Fix logical vs bitwise operator
- tests: drivers: bbram: refactoring
- cache: kconfig: Reorder and fix entries
- net: ip: Fix dereference before NULL check
- drivers: uart: Add return value to FIFO API callback set
- samples: drivers: uart: Detect missing FIFO mode in echo_bot
- net: l2: ieee802154: Fix address length macros
- net: l2: ieee802154: Fix logic with address types
- net: l2: ieee802154: AR shall be provided in association requests
- net: l2: ieee802154: Avoid dangling MAC command bits
- net: l2: ieee802154: Change the hardware filters while associating
- net: l2: ieee802154: Fix a wrong channel change during association
- net: l2: ieee802154: Add missing scan callback registration
- linker: kobject: Handle literal section
- samples: basic: blinky_pwm: fix divider setting for rpi_pico
- samples: drivers: led_pwm: enable immediate logging mode
- samples: drivers: led_pwm: fix divider setting for rpi_pico
- boards: rpi_pico: avoid conflicting use of LED
- samples: basic: fade_led: add support for rpi_pico board
- drivers: pwm: rpi_pico: fix setting of cycle count per period
- soc: arm: stm32g4: PM support
- boards: arm: nucleo_g474re & b_g474e_dpow1 PM support
- twister: Set a default gcov-tool for llvm
- mcux: flexcan: fixes the race condition
- dts: bindings: stm32: STM32U5: Use STM32L5 compatible
- drivers: flash: stm32: Rename _l5_u5.c driver to _l5x.c
- net: zperf: Make shell dependency optional
- net: lwm2m: add binaryappdatacontainer obj support
- drivers: adc: stm32g4 also have a shared IRQ for ADC instances
- net: lwm2m: Remove lwm2m_send_message() from public API
- net: lwm2m: Refactor lwm2m_information_interface_send()
- net: lwm2m: LwM2M Object path equal API
- net: lwm2m: LwM2M times series data update
- net: lwm2m: Add shell command to enable timeseries cache
- boards: nrf: Add GPIO support for Nordic-supported boards
- net: lwm2m: Add shell commands
- net: lib: sockets: support IPv6-only use case with AF_UNSPEC
- net: lib: sntp: add support for unspecified IP-family type
- tests: drivers: regulator: fixed: add nrf5340dk/nrf9160dk overlays
- toolchain: gcc: rename popcount to avoid conflict with C++20
- samples: mgmt: mcumgr: smp_svr: Removed un-needed UDP file
- tests: logging: log_msg: Fix test after mpsc_pbuf changes
- net: lwm2m: Deprecate Kconfig for LwM2M RD Client
- drivers: crypto: don't return uninitialized local variable
- dts: rp2040: Fixed DTC warning concerning the pinctrl node
- rpi_pico: Fix DTC warnings concerning the flash
- yamllint: fix all yamllint truthy errors
- yamllint: fix all yamllint brackets errors
- yamllint: fix all yamllint colons, commas and empty-lines errors
- yamllint: fix all yamllint hyphens errors
- yamllint: fix all yamllint comments errors
- yamllint: fix all yamllint comments-indentation errors
- yamllint: fix all yamllint line-length errors
- dts: bindings: drop "required: false" from base binding
- drivers: flash: stm32: Fix CmakeLists issue
- nxp/imx: fix imx6sx gpio pull up-down configuration
- maintainers: change lvgl status to "odd fixes"
- drivers: memc: don't relocate MEMC functions unless CONFIG_FLASH=y
- soc: esp32: add CCOUNT xtensa rate default value
- driver: clock: esp32: retrieve HW clock from DTS
- intel_adsp: ace: power: fix build error with asserts enabled
- boards/xtensa/esp32/esp32.dts: remove redundant button definition
- tests: drivers: uart: Add GPIO dependency to tests
- usb: dfu: Schedule timer handler from USB workqueue
- drivers: uart: add UART noise error enum
- drivers: serial: fix STM32 async uart driver
- drivers: can: document can_add_rx_filter_msgq() overrun behavior
- samples: canopennode: Fix typo
- tests: logging: drop duplicate test
- dts: bindings: fix a couple of key-duplicates in binding files
- samples, tests: fix key-duplicates in sample.yaml files
- ITE: drivers/i2c: Don't spam NACK error messages
- boards: riscv: add M5Stack STAMP-C3
- Bluetooth: Audio: Fix issue with deleting unicast groups
- Bluetooth: Audio: Add (un)bind of audio iso for streams
- Bluetooth: Audio: Add AUDIO_ISO debug logging
- Bluetooth: Audio: Fix issue with unicast client src/snk ASE count
- Bluetooth: Audio: Fix issue with creating unidirectional CIS
- drivers: memc: rename flexspi-hyperram driver to flexspi-s27ks0641
- drivers: memc: fix XIP active logic for RT6xx/RT5xx
- drivers: memc: introduce driver for APS6408L PSRAM
- soc: arm: add support for FlexSPI1 clock configuration for NXP RT5xx
- dts: arm: nxp: add missing interrupts property for RT5xx FlexSPI
- boards: arm: mimxrt595_evk: enable APS64 PSRAM on FlexSPI2
- samples: drivers: memc: add sample to test memory controllers
- gpio: Add dts binding for software debounce gpio
- gpio: Add driver support for software based gpio debounce
- gpio: Add tests for software based GPIO debounce driver
- gpio: Include GPIO_KEYS in documentation
- kernel: clarify documentation for k_work_reschedule_for_queue
- west: update manifest to the new zscilib revision.
- drivers: regulator: shell: fix isdigit() usage
- modules: hal_nordic: nrf_802154: RNG xor-shift algorithm
- yamllint: indentation: fix files in boards/
- yamllint: indentation: fix files in samples/
- yamllint: indentation: fix files in tests/
- yamllint: indentation: fix files in scripts/
- yamllint: indentation: fix dts/bindings/
- yamllint: indentation: MAINTAINERS and workflows
- dts: bindings: drop remaining "required: false" from bindings
- driver: systimer: increase esp32c3 tick resolution
- drivers: can: mcan: Fix flag overflow for some MCUs
- twister: bugfix: Make elf scan more precise.
- driver: can: add new filter to match CAN-FD frames
- tests: drivers: can: canfd: add support filter type frame
- scripts: dts: gen_driver_kconfig_dts: Use SafeLoader
- Bluetooth: att: Fix deadlock on meta data context allocation
- drivers: gpio: rename S32 to NXP S32
- drivers: serial: rename S32 to NXP S32
- drivers: pinctrl: rename S32 to NXP S32
- tests: clock_control: stm32h7: pll2: Fix test configuration
- scripts: compliance: add support for YAMLLint
- dts: nxp: power: Add a property for low power mode behavior
- drivers: memc: Add device PM to MCUX Flexspi driver
- soc: nxp: Add Power Management support for RT5xx
- boards: rt595: Changes to support Power management
- tests: pm_mgmt_soc: Enable additional configs for RT595 EVK
- tests: power_mgmt_soc: Add overlay for MXRT595 EVK
- drivers: counter: Update NXP LPC RTC for wakeup source
- samples: mimxrt595: Add Deep power down sample
- MAINTAINERS: remove incactive collaborators
- MAINTAINERS: add collborators to intel adsp area
- it8xxx2/espi: protect clear OBF request
- espi: it8xxx2: make sure h2ram offset is configured correctly
- pm: pm_device_runtime_enable/disable should return 0 when PM is disabled
- posix: clock: fix seconds calculation
- ztest: provide sys_clock_tick_set syscall
- tests: posix: clock: ensure overflow is consistent
- sensor: add helper function to convert micro Gs and m/s^2
- sensor: add helper function for convert radians and 10 micro degrees
- usb-c: Refactor USB-C Subsystem Sink
- usb_c: run clang-format
- usb_c: Use atomic arrays for PE flags
- usb_c: Check state machine array of states
- usb_c: Fix DPM request handlers
- usb_c: Properly handle Protocol Errors during DRS
- usb_c: Transition to Sink Ready on sender response timeout
- usb_c: Remove unnecessary code from PE_Send_Soft_Reset
- usb_c: Remove unnecessary PE_FLAGS_PROTOCOL_ERROR flag
- usb_c: Stop chunking_not_supported timer on exit
- samples: subsys: usb_c: sink: Add missing policy notifications
- net: lwm2m: Check return value from lwm2m_rd_client_pause/resume
- drivers: clock_control: esp32: fix cpu_freq divisor typo.
- net: lwm2m: support senml cbor object link
- net: lib: regenerate cbor code using zcbor
- net: lib: LwM2M SenML-Cbor regenrated files update
- net: lib: Patch file for generated code fix
- net: lwm2m: fix senml cbor object link encoding
- Bluetooth: audio: ascs: Fix possible race condition
- tests: libc: Fix "unused" type of warnings
- net: lwm2m: Verify data buffer size in lwm2m_engine_set()
- net: ipv4: Fix packet leak with IPv4 autoconf
- add sonar action
- dummy
