### PR TITLE
dts: update memory map and remove ext-uicr

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_0_8_0.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_0_8_0.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &suit_storage_partition;
+
+/ {
+	reserved-memory {
+		suit_storage_partition: memory@e1eb000 {
+			reg = <0xe1eb000 DT_SIZE_K(24)>;
+		};
+	};
+};

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_0_8_0.overlay
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_0_8_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf54h20dk_nrf54h20_0_8_0.dtsi"

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_0_8_0.overlay
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_0_8_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf54h20dk_nrf54h20_0_8_0.dtsi"

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr_0_8_0.overlay
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr_0_8_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf54h20dk_nrf54h20_0_8_0.dtsi"

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad_0_8_0.overlay
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad_0_8_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf54h20dk_nrf54h20_0_8_0.dtsi"

--- a/dts/bindings/arm/nordic,nrf-uicr-v2.yaml
+++ b/dts/bindings/arm/nordic,nrf-uicr-v2.yaml
@@ -17,10 +17,3 @@ properties:
     description: |
       Domain ID of the domain associated with this UICR instance. Must be unique
       across all UICR instances in the system.
-
-  ptr-ext-uicr:
-    type: phandle
-    required: true
-    description: |
-      Handle of a memory region reserved to contain an Extended UICR instance.
-      The address of that node will be stored in the UICR.PTREXTUICR register.

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -145,16 +145,8 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		suit_storage_partition: memory@e1eb000 {
-			reg = <0xe1eb000 DT_SIZE_K(24)>;
-		};
-
-		cpurad_uicr_ext: memory@e1ff000 {
-			reg = <0xe1ff000 DT_SIZE_K(2)>;
-		};
-
-		cpuapp_uicr_ext: memory@e1ff800 {
-			reg = <0xe1ff800 DT_SIZE_K(2)>;
+		suit_storage_partition: memory@e1ed000 {
+			reg = <0xe1ed000 DT_SIZE_K(20)>;
 		};
 	};
 
@@ -217,14 +209,12 @@
 			compatible = "nordic,nrf-uicr-v2";
 			reg = <0xfff8000 DT_SIZE_K(2)>;
 			domain = <2>;
-			ptr-ext-uicr = <&cpuapp_uicr_ext>;
 		};
 
 		cpurad_uicr: uicr@fffa000 {
 			compatible = "nordic,nrf-uicr-v2";
 			reg = <0xfffa000 DT_SIZE_K(2)>;
 			domain = <3>;
-			ptr-ext-uicr = <&cpurad_uicr_ext>;
 		};
 
 		ficr: ficr@fffe000 {

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -74,14 +74,6 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
-
-		cpurad_uicr_ext: memory@e401000 {
-			reg = <0xe401000 DT_SIZE_K(2)>;
-		};
-
-		cpuapp_uicr_ext: memory@e401800 {
-			reg = <0xe401800 DT_SIZE_K(2)>;
-		};
 	};
 
 	clocks {
@@ -113,14 +105,12 @@
 			compatible = "nordic,nrf-uicr-v2";
 			reg = <0xfff8000 DT_SIZE_K(2)>;
 			domain = <2>;
-			ptr-ext-uicr = <&cpuapp_uicr_ext>;
 		};
 
 		cpurad_uicr: uicr@fffa000 {
 			compatible = "nordic,nrf-uicr-v2";
 			reg = <0xfffa000 DT_SIZE_K(2)>;
 			domain = <3>;
-			ptr-ext-uicr = <&cpurad_uicr_ext>;
 		};
 
 		ficr: ficr@fffe000 {


### PR DESCRIPTION
Extended UICR will not be used as its configurations will be merged with the UICR registers in NVR.

Memory maps changes are needed to align with pre compiled firmware.